### PR TITLE
Allow local values in string evaluations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# New
+
+* [#3](https://github.com/vizor-games/jac/issues/2) Allow reference local values inside string evaluations
+
 # Version 0.0.3
 
 * Allow load configuration from custom locations

--- a/Readme.md
+++ b/Readme.md
@@ -143,6 +143,15 @@ release:
   server_name: "#{c.application_name}-release" # yields to my-awesome-app-release
 ```
 
+_local_ values can be referenced through self, e.g.:
+
+```yml
+default:
+  project:
+    network: fb
+    server_name: "#{self['network']}-srv" # => 'fb-srv'
+```
+
 All strings evaluated **after** profile is constructed thus
 you don't need to have declared values in current profile
 but be ready to get `nil`.

--- a/spec/jac/string_eval_spec.rb
+++ b/spec/jac/string_eval_spec.rb
@@ -1,0 +1,57 @@
+# Here all sophisticated specs placed. While configuration_spec.rb file
+# contains basic cases.
+
+require_relative lib('jac/configuration')
+
+include Jac
+
+describe Configuration do
+  context 'string evaluation' do
+    context 'whole object available through c / cfg / config variable' do
+      let(:conf) do
+        <<-CONFIG.strip_indent
+        default:
+          ref: 42
+          use: '\#{c.ref}'
+        CONFIG
+      end
+      it do
+        c = Configuration.read('default', conf)
+        expect(c.use).to eq('42')
+      end
+    end
+
+    context 'neighbour fields can be referenced without calling any object' do
+      let(:conf) do
+        <<-CONFIG.strip_indent
+        default:
+          project: x
+          projects:
+            project: y
+            eval_local: '\#{self["project"]}'
+            eval_global: '\#{c.project}'
+        CONFIG
+      end
+
+      it do
+        c = Configuration.read('default', conf)
+        expect(c.projects['eval_local']).to eq('y')
+        expect(c.projects['eval_global']).to eq('x')
+      end
+    end
+
+    context 'list elements can be accesed via `self[idx]`' do
+      let(:conf) do
+        <<-CONFIG.strip_indent
+        default:
+          list: ['1', '2', '3', "\#{self[1]}", "\#{self[0]}"]
+        CONFIG
+      end
+
+      it do
+        c = Configuration.read('default', conf)
+        expect(c.list).to match_array(%w[1 2 3 2 1])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow to reference values on same level of nested objects - e.g.

```yaml
default:
  project: 
     network: fb
     server_name: "#{c.project['network']}-srv"
```

can be replaced with

```yaml
default:
  project: 
     network: fb
     server_name: "#{self['network']}-srv"
```
